### PR TITLE
build,test,doc: add makefile, add integration test, update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode
+package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+all: test
+
+build: clean
+	appsody stack package
+
+test: build
+	appsody stack validate --no-package
+
+clean:
+	rm -rf templates/default/node_modules templates/default/package-lock.json

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This template only has a simple `index.js` file which implements the `/` endpoin
     ```bash
     mkdir my-project
     cd my-project
-    appsody init experimental/ce-functions
+    appsody init experimental/node-ce-functions
     ```
 
     This will initialize a Node.js Cloud Event functions project using the default template.

--- a/image/project/package.json
+++ b/image/project/package.json
@@ -15,7 +15,7 @@
     "test": "tape test/test.js | tap-spec"
   },
   "dependencies": {
-    "@redhat/faas-js-runtime": "0.1.0",
+    "@redhat/faas-js-runtime": "0.2.0",
     "cloudevents-sdk": "v1.0.0",
     "overload-protection": "^1.1.0"
   },

--- a/image/project/test/test.js
+++ b/image/project/test/test.js
@@ -1,41 +1,17 @@
 'use strict';
 
-const runtime = require('..');
 const test = require('tape');
 const request = require('supertest');
 
-// test('Loads a user function with dependencies', t => {
-//   framework(func, server => {
-//     t.plan(2);
-//     request(server)
-//       .get('/')
-//       .expect(200)
-//       .expect('Content-Type', /json/)
-//       .end((err, res) => {
-//         t.error(err, 'No error');
-//         t.equal(res.body, 'This is the test function for Node.js FaaS. Success.');
-//         t.end();
-//         server.close();
-//       });
-//     }, { log: false });
-// });
+const runtime = require('..');
 
-// test('Can respond via an async function', t => {
-//   framework(func, server => {
-//     t.plan(2);
-//     request(server)
-//       .get('/')
-//       .expect(200)
-//       .expect('Content-Type', /json/)
-//       .end((err, res) => {
-//         t.error(err, 'No error');
-//         t.equal(res.body,
-//           'This is the test function for Node.js FaaS. Success.');
-//         t.end();
-//         server.close();
-//       });
-//     }, { log: false });
-// });
+const Spec = {
+  version: 'ce-specversion',
+  type: 'ce-type',
+  id: 'ce-id',
+  source: 'ce-source'
+};
+
 const server = 'http://localhost:8080';
 
 test('Exposes readiness URL', t => {
@@ -60,6 +36,24 @@ test('Exposes liveness URL', t => {
     .end((err, res) => {
       t.error(err, 'No error');
       t.equal(res.text, 'OK');
+      t.end();
+    });
+});
+
+test('Handles a valid event', t => {
+  t.plan(2);
+  request(server)
+    .post('/')
+    .send({ message: 'hello' })
+    .set(Spec.id, 'TEST-EVENT-1')
+    .set(Spec.source, 'http://localhost:8080/integration-test')
+    .set(Spec.type, 'dev.faas.example')
+    .set(Spec.version, '1.0')
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end((err, res) => {
+      t.error(err, 'No error');
+      t.equal(res.body.data.message, 'hello');
       t.end();
     });
 });

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 name: JavaScript FaaS
 version: 0.0.1
-description: Node.js Function Runtime
+description: Node.js function runtime for cloud events
 license: Apache-2.0
 language: JavaScript
 maintainers:

--- a/templates/default/index.js
+++ b/templates/default/index.js
@@ -1,5 +1,11 @@
 'use strict';
 
-module.exports = function(context) {
-  context.log.info(context);
+module.exports = function (context) {
+  if (!context.cloudevent) {
+    return new Error('No cloud event received');
+  }
+  context.log.info(`Cloud event received: ${context.cloudevent}`);
+  return {
+    data: context.cloudevent.data
+  }
 };

--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -11,7 +11,9 @@
     "test": "node test/*.js"
   },
   "devDependencies": {
-    "tape": "^4.13.0",
-    "cloudevents-sdk": "^1.0.0"
+    "@redhat/faas-js-runtime": "0.2.0",
+    "cloudevents-sdk": "^1.0.0",
+    "supertest": "^4.0.2",
+    "tape": "^4.13.0"
   }
 }

--- a/templates/default/test/integration.js
+++ b/templates/default/test/integration.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const runtime = require('@redhat/faas-js-runtime');
+const request = require('supertest');
+
+const func = require('..');
+const test = require('tape');
+const cloudevents = require('cloudevents-sdk/v1');
+
+const Spec = {
+  version: 'ce-specversion',
+  type: 'ce-type',
+  id: 'ce-id',
+  source: 'ce-source'
+};
+
+test('Handles a valid event', t => {
+  runtime(func, server => {
+    t.plan(1);
+    request(server)
+      .post('/')
+      .send({ message: 'hello' })
+      .set(Spec.id, 'TEST-EVENT-1')
+      .set(Spec.source, 'http://localhost:8080/integration-test')
+      .set(Spec.type, 'dev.faas.example')
+      .set(Spec.version, '1.0')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end((err, res) => {
+        t.error(err, 'No error');
+        // Check response values that your function produces
+        // t.equal(res.body.data.message, 'hello');
+        t.end();
+        server.close();
+      });
+  }, { log: false });
+});
+

--- a/templates/default/test/unit.js
+++ b/templates/default/test/unit.js
@@ -6,13 +6,15 @@ const cloudevents = require('cloudevents-sdk/v1');
 
 // Ensure that the function completes cleanly when passed a valid event.
 test('Handles a valid event', t => {
+  t.plan(1);
   // A valid event includes id, type and source at a minimum.
-  let e = cloudevents.event();
-  e.id('TEST-EVENT-01');
-  e.type('com.example.cloudevents.test');
-  e.source('http://localhost:8080/');
+  const cloudevent = cloudevents.event()
+    .id('TEST-EVENT-01')
+    .type('com.example.cloudevents.test')
+    .source('http://localhost:8080/')
+    .data({ message: 'hello' });
 
   // Invoke the function with the valid event, which should compelte without error.
-  func({ cloudevent: e });
+  t.ok(func({ cloudevent }));
   t.end();
 });


### PR DESCRIPTION
Update template tests to include both unit tests, invoking the function directly, and integration tests - invoking via a cloud event over HTTP.

Added a Makefile to make build/test simpler.

Bumped faas-js-runtime dependency to 0.2.0.