### PR TITLE
templates: add a README and local execution for default

### DIFF
--- a/templates/default/README.md
+++ b/templates/default/README.md
@@ -1,0 +1,58 @@
+# Node.js Cloud Events Function
+
+Welcome to your new Node.js function project! The boilerplate function code can be found in [`index.js`](./index.js). This function is meant to respond exclusively to [Cloud Events](https://cloudevents.io/), but you can remove the check for this in the function and it will respond just fine to plain vanilla incoming HTTP requests. Additionally, this example function is written asynchronously, returning a `Promise`. If your function does not perform any asynchronous execution, you can safely remove the `async` keyword from the function, and return raw values intead of a `Promise`.
+
+## Local execution
+
+After executing `npm install`, you can run this function locally by executing `npm run local`.
+
+The runtime will expose three endpoints.
+
+  * `/` The endpoint for your function.
+  * `/health/readiness` The endpoint for a readiness health check
+  * `/health/liveness` The endpoint for a liveness health check
+
+The health checks can be accessed in your browser at [http://localhost:8080/health/readiness]() and [http://localhost:8080/health/liveness](). You can use `curl` to `POST` an event to the function endpoint:
+
+```console
+curl -X POST -d '{"hello": "world"}' \
+  -H'Content-type: application/json' \
+  -H'Ce-id: 1' \
+  -H'Ce-source: cloud-event-example' \
+  -H'Ce-type: dev.knative.example' \
+  -H'Ce-specversion: 0.2' \
+  http://localhost:8080
+```
+
+The readiness and liveness endpoints use [overload-protection](https://www.npmjs.com/package/overload-protection) and will respond with `HTTP 503 Service Unavailable` with a `Client-Retry` header if your function is determined to be overloaded, based on the memory usage and event loop delay.
+
+## Container execution
+
+It is easy to run this function in a container, simulating its execution environment on a Kubernetes cluster. When running this way, the container's port `8080` is mapped to your local port `8080`, so you can access the endpoints exactly the same as you do when running on `localhost`.
+
+```console
+appsody run
+```
+
+When running in the container, your function will be reloaded when it changes so that you can edit your source code and see the changes reflected in your browser immediately. Try it! Start your application using `appsody run`, then change [index.js](./index.js) so that it returns `'Hello world!'` if there is no incoming Cloud Event.
+
+## Testing
+
+This function project includes a [unit test](./test/unit.js) and an [integration test](./test/integration.js). Tests can either be run locally, or within a container execution environment. In either execution environment, all `.js` files in the test directory are run.
+
+### Local testing
+
+```console
+npm test
+```
+
+### Container testing
+
+```console
+appsody test
+```
+
+## Deployment
+
+TODO: Document deploying this cluster to a Kubernetes cluster running Knative Serving and Eventing.
+

--- a/templates/default/local.js
+++ b/templates/default/local.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const runtime = require('@redhat/faas-js-runtime');
+const func = require('./index.js');
+const ON_DEATH = require('death')({ uncaughtException: true });
+
+runtime(func, server => {
+  ON_DEATH(_ => {
+    server.close();
+  });
+
+  console.log(`
+The server has started.
+
+You can use curl to POST an event to the endpoint:
+
+curl -X POST -d '{"hello": "world"}' \\
+    -H'Content-type: application/json' \\
+    -H'Ce-id: 1' \\
+    -H'Ce-source: cloud-event-example' \\
+    -H'Ce-type: dev.knative.example' \\
+    -H'Ce-specversion: 0.2' \\
+    http://localhost:8080
+  `);
+});

--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -8,11 +8,13 @@
     "url": ""
   },
   "scripts": {
-    "test": "node test/*.js"
+    "test": "node test/*.js",
+    "local": "node local.js"
   },
   "devDependencies": {
     "@redhat/faas-js-runtime": "0.2.0",
     "cloudevents-sdk": "^1.0.0",
+    "death": "^1.1.0",
     "supertest": "^4.0.2",
     "tape": "^4.13.0"
   }


### PR DESCRIPTION
The default function template should run locally without requiring
container execution. This change adds a `local.js` file to the template
and a script in `package.json` in order to enable that. Additionally, I
added a README to the template to help users getting started.