### PR TITLE
ci,doc: configure Circle CI and add README badge 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,11 @@ version: 2
 general:
   branches:
     only:
-      - ci # TODO: Change this once we have CI building correctly
+      - master
+      - ci
 jobs:
  build:
-   machine:
+   machine: # Because appsody mounts local directories into running test container
     image: ubuntu-1604:201903-01
    steps:
      - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ general:
       - ci # TODO: Change this once we have CI building correctly
 jobs:
  build:
-   machine: true
-    image: cimg/base:2020.03
+   machine:
+    image: ubuntu-1604:201903-01
    steps:
      - checkout
      - run: ./ci/install_appsody.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Node.js Cloud Events Stack
 
+[![CircleCI](https://circleci.com/gh/openshift-cloud-functions/node-ce-functions/tree/master.svg?style=svg)](https://circleci.com/gh/openshift-cloud-functions/node-ce-functions/tree/master)
+
 **THIS IS A PROOF OF CONCEPT IMPLEMENTATION**
 
 This stack provides a Node.js framework for executing a function that


### PR DESCRIPTION
Configures circle CI correctly using a `machine` executor, and adds a readme badge.