### PR TITLE
fix: mock context.log in template unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ curl -X POST -d '{"hello": "world"}' \
   -H'Ce-id: 1' \
   -H'Ce-source: cloud-event-example' \
   -H'Ce-type: dev.knative.example' \
-  -H'Ce-specversion: 0.2' \
+  -H'Ce-specversion: 1.0' \
   http://localhost:8080
 ```
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 name: JavaScript FaaS
-version: 0.0.2
+version: 0.0.4
 description: Node.js function runtime for cloud events
 license: Apache-2.0
 language: JavaScript

--- a/templates/default/README.md
+++ b/templates/default/README.md
@@ -20,7 +20,7 @@ curl -X POST -d '{"hello": "world"}' \
   -H'Ce-id: 1' \
   -H'Ce-source: cloud-event-example' \
   -H'Ce-type: dev.knative.example' \
-  -H'Ce-specversion: 0.2' \
+  -H'Ce-specversion: 1.0' \
   http://localhost:8080
 ```
 

--- a/templates/default/local.js
+++ b/templates/default/local.js
@@ -19,7 +19,7 @@ curl -X POST -d '{"hello": "world"}' \\
     -H'Ce-id: 1' \\
     -H'Ce-source: cloud-event-example' \\
     -H'Ce-type: dev.knative.example' \\
-    -H'Ce-specversion: 0.2' \\
+    -H'Ce-specversion: 1.0' \\
     http://localhost:8080
   `);
 });

--- a/templates/default/test/unit.js
+++ b/templates/default/test/unit.js
@@ -15,6 +15,6 @@ test('Unit: andles a valid event', t => {
     .data({ message: 'hello' });
 
   // Invoke the function with the valid event, which should compelte without error.
-  t.ok(func({ cloudevent }));
+  t.ok(func({ cloudevent, log: { info: console.log } }));
   t.end();
 });


### PR DESCRIPTION
This commit also bumps the stack version to the unreleased v0.0.4
and changes the ce-specversion header examples to use 1.0.

Signed-off-by: Lance Ball <lball@redhat.com>